### PR TITLE
Chain CI workflows sequentially

### DIFF
--- a/.github/workflows/feature_pipeline.yaml
+++ b/.github/workflows/feature_pipeline.yaml
@@ -2,7 +2,7 @@ name: feature-pipeline
 
 on:
   schedule:
-  - cron: '0 0 * * 0'
+  - cron: "0 0 * * 0"
 
   workflow_dispatch:
 

--- a/.github/workflows/inference_pipeline.yml
+++ b/.github/workflows/inference_pipeline.yml
@@ -5,8 +5,6 @@ on:
     workflows: ["feature-pipeline"]
     types:
       - completed
-  schedule:
-    - cron: '0 0 * * 0'
 
   workflow_dispatch:
 

--- a/.github/workflows/training_pipeline.yaml
+++ b/.github/workflows/training_pipeline.yaml
@@ -1,10 +1,12 @@
 name: training-pipeline
 
 on:
-    schedule:
-    - cron: '0 0 * * 0'
-  
-    #workflow_dispatch:
+  workflow_run:
+    workflows: ["inference-pipeline"]
+    types:
+      - completed
+
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: 3.9


### PR DESCRIPTION
## Summary
- Ensure feature pipeline runs at midnight Sunday before downstream steps
- Trigger inference pipeline only after the feature pipeline completes
- Trigger training pipeline after inference to run workflows sequentially

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a59216797c832d93ae87db1763c0bb